### PR TITLE
Fixed syntax issues in generating vtund.conf

### DIFF
--- a/root/setup/vtun.sh
+++ b/root/setup/vtun.sh
@@ -54,9 +54,9 @@ ${name}-${s[0]}-${s[1]}-${s[2]}-${s[3]} {
   device tun${tun};
   passwd ${password};
   up {
-    ifconfig "%% ${remoteip} netmask 255.255.255.252 pointtopoint ${localip} mtu 1450";
+    ifconfig "%% ${remoteip} netmask 255.255.255.252 pointopoint ${localip} mtu 1450";
     route "add -net ${net}/30 gw ${localip}";
-  }
+  };
 }
 __EOF__
   else
@@ -66,9 +66,9 @@ ${name}-${s[0]}-${s[1]}-${s[2]}-${s[3]} {
   device tun${tun};
   passwd ${password};
   up {
-    ifconfig "%% ${localip} netmask 255.255.255.252 pointtopoint ${remoteip} mtu 1450";
+    ifconfig "%% ${localip} netmask 255.255.255.252 pointopoint ${remoteip} mtu 1450";
     route "add -net ${net}/30 gw ${remoteip}";
-  }
+  };
 }
 __EOF__
     run="${run};vtund ${name}-${s[0]}-${s[1]}-${s[2]}-${s[3]} ${target}"


### PR DESCRIPTION
While working on bringing up a supernode, it was noticed that if more than one tunnel is added to the configuration `vtund` would start complaining about the configuration. 

```
root@wt0f-sn:/etc# vtund -s
vtund[902]: Invalid clause 'KD4WLE-SN-172-100-21-0' line 18
```

This was caused by not ending the `up` block with a semicolon. Once this was added to the setup script the invalid clause error was resolved. 

In addition, it was found that the `pointopoint` option to `ifconfig` was misspelled. It was being written to the configuration file as `pointtopoint` (note the second t). Please refer to  https://man7.org/linux/man-pages/man8/ifconfig.8.html as it is called out there as `pointopoint` in at least 2 places. 

