### PR TITLE
Added support to build docker container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: Build Docker image
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  # lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Lint with flake8
+  #     run: |
+  #       # stop the build if there are Python syntax errors or undefined names
+  #       flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  #       # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+  #       flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  
+  build_docker_image:
+    name: Docker Build
+    runs-on: ubuntu-22.04
+    # needs:
+    #   - lint
+    steps:
+      - name: Publishing info
+        run: |
+          echo "Pushing docker image: ghcr.io/hickey/supernode:$GITHUB_REF_NAME"
+          echo "Pushing docker image: ghcr.io/hickey/supernode:$GITHUB_SHA"
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Auth to GitHub registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/hickey/supernode:${{ github.ref_name }}
+            ghcr.io/hickey/supernode:${{ github.sha }}


### PR DESCRIPTION
This change adds a GitHub Action for building consistent Docker images. This eliminates the need for individuals from having to create their own Docker images. Especially when they don't have a great deal of Docker knowledge (one of the problems we have had here in Florida). 

This change also uploads the container image to the GitHub container registry and opens the door to having semantically versioned images. I will have another a follow on PR to add another GitHub Action to enable automated releases using conventional commits. 