### PR TITLE
Refactored Dockerfile to be multistage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-20210902-slim
+FROM debian:stable-20210902-slim AS build
 
 RUN apt update ;\
     apt install -y git build-essential bison flex libgps-dev vtun bind9 iptables inotify-tools net-tools dnsutils procps
@@ -12,11 +12,16 @@ RUN mkdir build ;\
     cd / ;\
     rm -rf build
 
-RUN apt autoremove -y git build-essential bison flex libgps-dev
+FROM debian:stable-20210902-slim
 
 EXPOSE 698/udp 8081/tcp 53/udp 53/tcp
 
 COPY root/ /
-RUN chmod 777 /startup.sh /setup/*.sh /named/*.sh
+COPY --from=build /usr/local/sbin/ /usr/local/sbin/
+COPY --from=build /etc/olsrd/ /etc/olsrd/
+RUN chmod 777 /startup.sh /setup/*.sh /named/*.sh && \
+    apt update -y && \
+    apt install -y libgps-dev vtun bind9 iptables inotify-tools net-tools dnsutils procps && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 ENTRYPOINT ["/startup.sh"]


### PR DESCRIPTION
Moving to a multstage build for the Docker container allows the resulting image to be considerably smaller than what is build currently. The existing Docker build results in an image about 620MB, but with the multistage build the resulting image is about a third in size. 

```
REPOSITORY                 TAG               IMAGE ID       CREATED          SIZE
ghcr.io/hickey/supernode   multstage-build   5518eb26b168   18 minutes ago   210MB
ghcr.io/hickey/supernode   master            20776805236b   40 minutes ago   618MB
```